### PR TITLE
Decrease stale job frequency

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,7 +7,7 @@ name: Mark stale issues and pull requests
 
 on:
   schedule:
-  - cron: '0 * * * *'
+  - cron: '0 0 * * *'
 
 jobs:
   stale:


### PR DESCRIPTION
Runs every midnight instead of hourly, sometimes the job fails and get spammed with failed pipeline notifications